### PR TITLE
Feature/step 04 coordinate area of triangle

### DIFF
--- a/src/main/java/step04/domain/Geometry.java
+++ b/src/main/java/step04/domain/Geometry.java
@@ -8,6 +8,10 @@ public abstract class Geometry {
 		if (splitInput.length == 2) {
 			return new Line(new Point(splitInput[0]), new Point(splitInput[1]));
 		}
+		if (splitInput.length == 3) {
+			return new Triangle(new Point(splitInput[0]), new Point(splitInput[1]),
+					new Point(splitInput[2]));
+		}
 		if (splitInput.length == 4) {
 			return new Square(new Point(splitInput[0]), new Point(splitInput[1]),
 					new Point(splitInput[2]), new Point(splitInput[3]));

--- a/src/main/java/step04/domain/Square.java
+++ b/src/main/java/step04/domain/Square.java
@@ -1,5 +1,8 @@
 package step04.domain;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class Square extends Geometry {
 
 	private final Point pointSW;
@@ -7,17 +10,47 @@ public class Square extends Geometry {
 	private final Point pointNE;
 	private final Point pointNW;
 
-	public Square(
-			Point pointSW, Point pointSE, Point pointNE, Point pointNW) {
-		this.pointSW = pointSW;
-		this.pointSE = pointSE;
-		this.pointNE = pointNE;
-		this.pointNW = pointNW;
+	public Square(Point pointOne, Point pointTwo, Point pointThree, Point pointFour) {
+		this(Arrays.asList(pointOne, pointTwo, pointThree, pointFour));
+	}
+
+	private Square(List<Point> points) {
+		points = placeAllPoints(points);
+		this.pointSW = points.get(0);
+		this.pointSE = points.get(1);
+		this.pointNE = points.get(2);
+		this.pointNW = points.get(3);
 	}
 
 	public double area() {
 		double width = super.length(pointSW, pointSE);
 		double height = super.length(pointSE, pointNE);
 		return width * height;
+	}
+
+	private List<Point> placeAllPoints(List<Point> points) {
+		int minX = points.stream().mapToInt(Point::getXposition).min().getAsInt();
+		int minY = points.stream().mapToInt(Point::getYposition).min().getAsInt();
+		int maxX = points.stream().mapToInt(Point::getXposition).max().getAsInt();
+		int maxY = points.stream().mapToInt(Point::getYposition).max().getAsInt();
+
+		Point[] organizedPoints = new Point[4];
+
+		for (Point point : points) {
+			if (point.getXposition() == minX && point.getYposition() == minY) {
+				organizedPoints[0] = point;
+			}
+			if (point.getXposition() == maxX && point.getYposition() == minY) {
+				organizedPoints[1] = point;
+			}
+			if (point.getXposition() == maxX && point.getYposition() == maxY) {
+				organizedPoints[2] = point;
+			}
+			if (point.getXposition() == minX && point.getYposition() == maxY) {
+				organizedPoints[3] = point;
+			}
+		}
+
+		return Arrays.asList(organizedPoints);
 	}
 }

--- a/src/main/java/step04/domain/Square.java
+++ b/src/main/java/step04/domain/Square.java
@@ -34,23 +34,11 @@ public class Square extends Geometry {
 		int maxX = points.stream().mapToInt(Point::getXposition).max().getAsInt();
 		int maxY = points.stream().mapToInt(Point::getYposition).max().getAsInt();
 
-		Point[] organizedPoints = new Point[4];
+		Point pointSW = new Point(new Position(minX), new Position(minY));
+		Point pointSE = new Point(new Position(maxX), new Position(minY));
+		Point pointNE = new Point(new Position(maxX), new Position(maxY));
+		Point pointNW = new Point(new Position(minX), new Position(maxY));
 
-		for (Point point : points) {
-			if (point.getXposition() == minX && point.getYposition() == minY) {
-				organizedPoints[0] = point;
-			}
-			if (point.getXposition() == maxX && point.getYposition() == minY) {
-				organizedPoints[1] = point;
-			}
-			if (point.getXposition() == maxX && point.getYposition() == maxY) {
-				organizedPoints[2] = point;
-			}
-			if (point.getXposition() == minX && point.getYposition() == maxY) {
-				organizedPoints[3] = point;
-			}
-		}
-
-		return Arrays.asList(organizedPoints);
+		return Arrays.asList(pointSW, pointSE, pointNE, pointNW);
 	}
 }

--- a/src/main/java/step04/domain/Triangle.java
+++ b/src/main/java/step04/domain/Triangle.java
@@ -1,0 +1,21 @@
+package step04.domain;
+
+public class Triangle extends Geometry {
+	private final Point pointOne;
+	private final Point pointTwo;
+	private final Point pointThree;
+
+	public Triangle(Point pointOne, Point pointTwo, Point pointThree) {
+		this.pointOne = pointOne;
+		this.pointTwo = pointTwo;
+		this.pointThree = pointThree;
+	}
+
+	public double area() {
+		double lineOne = super.length(pointOne, pointTwo);
+		double lineTwo = super.length(pointTwo, pointThree);
+		double lineThree = super.length(pointThree, pointOne);
+		double s = (lineOne + lineTwo + lineThree) / 2;
+		return Math.sqrt(s * (s - lineOne) * (s - lineTwo) * (s - lineThree));
+	}
+}

--- a/src/main/java/step04/view/CoordinateView.java
+++ b/src/main/java/step04/view/CoordinateView.java
@@ -3,16 +3,22 @@ package step04.view;
 import step04.domain.Line;
 import step04.domain.Geometry;
 import step04.domain.Square;
+import step04.domain.Triangle;
 
 public class CoordinateView {
 
 	private static final String REPORT_LINE_LENGTH = "두 점 사이 거리는 ";
 	private static final String REPORT_SQUARE_AREA = "사각형 넓이는 ";
+	private static final String REPORT_TRIANGLE_AREA = "삼각형 넓이는 ";
 
 	public void printResult(Geometry geometry) {
 		if (geometry instanceof Line) {
 			Line line = (Line) geometry;
 			System.out.println(REPORT_LINE_LENGTH + line.length());
+		}
+		if (geometry instanceof Triangle) {
+			Triangle triangle = (Triangle) geometry;
+			System.out.println(REPORT_TRIANGLE_AREA + triangle.area());
 		}
 		if (geometry instanceof Square) {
 			Square square = (Square) geometry;

--- a/src/test/java/step04/domain/SquareTest.java
+++ b/src/test/java/step04/domain/SquareTest.java
@@ -1,0 +1,21 @@
+package step04.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SquareTest {
+	@Test
+	@DisplayName("사각형의 넓이를 리턴한다.")
+	void areaTest(){
+		Point pointOne = new Point("10,10");
+		Point pointTwo = new Point("22,10");
+		Point pointThree = new Point("22,18");
+		Point pointFour = new Point("10,18");
+
+		Square puddleSquare = new Square(pointOne, pointThree, pointTwo, pointFour);
+		assertThat(puddleSquare.area()).isEqualTo(96, offset(0.00099));
+	}
+}

--- a/src/test/java/step04/domain/TriangleTest.java
+++ b/src/test/java/step04/domain/TriangleTest.java
@@ -1,0 +1,21 @@
+package step04.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TriangleTest {
+	@Test
+	@DisplayName("삼각형의 넓이를 리턴한다.")
+	void areaTest(){
+
+		Point pointOne = new Point("10,10");
+		Point pointTwo = new Point("14,15");
+		Point pointThree = new Point("20,8");
+
+		Triangle triangle = new Triangle(pointOne, pointTwo, pointThree);
+		assertThat(triangle.area()).isEqualTo(29.0, offset(0.00099));
+	}
+}


### PR DESCRIPTION
## 회고
step3 에서 구현해 놓은 것을 토대로 step4 를 구현하는 것은 굉장히 편리했다. 그런데 의문점이 하나 있다. 추상클래스와 인터페이스를 쓰는 이유는 프로그램의 확장성을 위함이다. 그렇다면 내가 작성한 코드는 확장에 유연한 코드가 맞는가?

우선 `Triangle` 클래스를 만드는 것은 당연한 일이고, 이로 인해 영향 받게 되는 다른 클래스를 조명하고자 한다.

첫 번째는 `Geometry` 추상 클래스이다. 내부에 crate() 팩토리 메서드가 있기 때문에 Triangle에 대응하는 코드를 추가해야 했다.
두 번째는 `CoordinateView:;printResult()` 메서드이다. 역시 Triangle에 대응하는 코드를 추가했다.

대신에 main() 메서드를 가지고 있는 CoordinateApplication는 변경되지 않았다. 이렇게 하는게 맞을까? 우선 CoordinateView는 Geometry에서 추상 메서드 구현하는 것이 가능할 수 있지 않을까? 이렇게 되면 CoordinateView의 변경이 더 이상 필요 없을 뿐만 아니라 CoordinateView 클래스 자체가 없어져도 된다. 그러나 view를 위한 sout 구문이 각 클래스 안에 들어가게 될 것이다. 
```java
@Override
public void printResult() {
System.out.println("사각형 넓이는 " + area()); // 물론 문자열을 그대로 넣는 것이 아닌 클래스 상수를 선언해야 할 것이다.
}
```

어떤 것이 옳은건지 모르겠다. 나는 CoordinateView 클래스를 없애면 진정한 DI가 될 것이라고 생각한다. 
```java
	public static void main(String[] args) {
		Scanner scanner = new Scanner(System.in);
		System.out.println(ASK_COORDINATE);
		String input = scanner.nextLine();

		Geometry geometry = Geometry.crate(input);
		geometry.printResult();
	}
```

피드백 강의를 본 후에 재구현에서 결정하는 것이 좋겠다.


## Square fix
내가 작성한 Square 클래스에는 한 가지 심각한 문제점이 있었다.
Square 클래스가 가진 Point 내부 변수는 SW, SE, NE, NW 으로 Point의 좌표 값에 따른 위치를 이름으로 가지고 있다. 각 Point를 사각형의 꼭지점으로 지정한 것이다.
예를 들어 step03 리드미의 예시 좌표인 '(10,10)-(22,10)-(22,18)-(10,18)' 의 경우
![정상 좌표](https://github.com/PhiloMonx1/java-coordinate-playground/assets/99243066/75ad28c8-5ae4-45c4-82cd-b03d036db8cf)
이와 같이 각 포인트의 위치를 사각형의 꼭지점으로 가정하고 그 순서대로 선을 긋는 것이다.
```java
width = super.length(pointSW, pointSE);
height = super.length(pointSE, pointNE);
```
그리고 이렇게 가로변과 세로변의 길이를 구해 사각형의 면적을 구하고 있다.

그렇다면 좌표가 '(10,10)-(22,18)-(22,10)-(10,18)'인 경우는 어떨까?
![비정상 좌표](https://github.com/PhiloMonx1/java-coordinate-playground/assets/99243066/6f005e39-469d-401e-96c5-48f1a1fd3450)
이와 같은 모습이 된다. 나는 들어오는 순서대로  SW, SE, NE, NW 를 지정했기 때문이다.

![테스트 실패](https://github.com/PhiloMonx1/java-coordinate-playground/assets/99243066/18f72faf-3a88-4688-862e-8b2c56b1c396)
당연히 테스트도 실패한다. 

해당 문제를 해결하기 위해 2가지 방법이 있다.

1. width와 height를 구하는 로직을 개선한다.
    - x값이 같은 Point의 y 값 차이가 height 이다.
    - y값이 같은 Point의 x 값 차이가 width 이다.
2. Point의 x, y 값을 비교하여 SW, SE, NE, NW를 뽑아낸다.
    - x값과 y값이 가장 작은 Point가 SW이다.
    - x값은 가장 크고  y값이 가장 작은 Point가 SE이다.
    - x값과 y값이 가장 큰 Point가 NE이다.
    - x값이 가장 작고 y값이 가장 큰 Point가 NW이다.

나는 2번을 선택했는데, 직관적으로 1번보다 구현이 더 간단할 것 이라고 생각했기 때문이다. 또한 SW, SE, NE, NW라는 변수명이 단순히 4개의 포인트를 가지고 있는 것보다는 사각형을 이해하는데 도움이 될 것이라고 생각했다. 
이로 인해 [Fix](https://github.com/PhiloMonx1/java-coordinate-playground/pull/7/commits/bdf39d3d4070ed01c04872eeda981d9e6dccb711) 커밋을 작성하게 되었다. 그리고 한 단계의 들여쓰기만 사용하기 위해서 [Refactor](https://github.com/PhiloMonx1/java-coordinate-playground/pull/7/commits/75f68df0044f07fc09d924ca7e4af1a6fb7fd578) 커밋으로 개선했다.

나는 이 개선이 맞는 개선인지 의문이 든다. if문과 for문을 사용하지 않는 장점이 있지만 Point 인스턴스를 새로 생성하는 방법을 사용했으니 메서드의 동작이 직관적으로 이해되지 않는 것 같다. 왜 이런 메서드를 적었는지 다른 사람이 봐도 직관적으로 알 수 있을까?