### PR TITLE
Refactor(좌표계산기_피드백) : `FigureFactory::getInstance()` 내부 구현 로직 `FigureCreator::create()`로 구현하도록 개선

### DIFF
--- a/src/main/java/exercise_polymorphism/FigureCreator.java
+++ b/src/main/java/exercise_polymorphism/FigureCreator.java
@@ -3,5 +3,20 @@ package exercise_polymorphism;
 import java.util.List;
 
 public interface FigureCreator {
-    Figure create(List<Point> points);
+
+	static Figure create(List<Point> points) {
+		if (points.size() == Line.LINE_POINT_SIZE) {
+			return new Line(points);
+		}
+
+		if (points.size() == Triangle.TRIANGLE_POINT_SIZE) {
+			return new Triangle(points);
+		}
+
+		if (points.size() == Rectangle.RECTANGLE_POINT_SIZE) {
+			return new Rectangle(points);
+		}
+
+		throw new IllegalArgumentException("유효하지 않은 도형입니다.");
+	}
 }

--- a/src/main/java/exercise_polymorphism/FigureFactory.java
+++ b/src/main/java/exercise_polymorphism/FigureFactory.java
@@ -4,18 +4,6 @@ import java.util.List;
 
 public class FigureFactory {
     static Figure getInstance(List<Point> points) {
-        if (points.size() == Line.LINE_POINT_SIZE) {
-            return new Line(points);
-        }
-
-        if (points.size() == Triangle.TRIANGLE_POINT_SIZE) {
-            return new Triangle(points);
-        }
-
-        if (points.size() == Rectangle.RECTANGLE_POINT_SIZE) {
-            return new Rectangle(points);
-        }
-
-        throw new IllegalArgumentException("유효하지 않은 도형입니다.");
+        return FigureCreator.create(points);
     }
 }


### PR DESCRIPTION
이렇게 하는게 맞는건지 모르겠다. 우선 메서드명에 맞게 구현하긴 했으나 내가 한 것은 `FigureFactory::getInstance()` 안에 있는 내용을 `FigureCreator::create()` 안에 붙여넣었을 뿐이다. 이로 인해 `FigureCreator::create()` 메서드는 static 상태를 가지게 되었다. 